### PR TITLE
Property Name Not Mapped when Serializing 

### DIFF
--- a/Cereal/Serialization/Cerealizer.m
+++ b/Cereal/Serialization/Cerealizer.m
@@ -95,7 +95,10 @@
         else if ([value conformsToProtocol: @protocol(NSObject)])
             value = [self toObject: value];
 
-        [dictionary setValue: value forKey: propertyInfo.name];
+        NSString* valueKey = propertyInfo.name;
+        if ([object conformsToProtocol: @protocol(Cerealizable)] && [object respondsToSelector: @selector(valueKeyForPropertyName:)])
+            valueKey = [object valueKeyForPropertyName: propertyInfo.name];
+        [dictionary setValue: value forKey: valueKey];
     }
     return dictionary;
 }


### PR DESCRIPTION
The serialization logic was not calling valueKeyForPropertyName to perform the custom property name to value key mapping.
