### PR TITLE
Fixed issue where serializer would create a blank NSDictionary when a…

### DIFF
--- a/Cereal/Serialization/CerealizerBase.swift
+++ b/Cereal/Serialization/CerealizerBase.swift
@@ -150,6 +150,11 @@ public class CerealizerBase: NSObject, Cerealizer {
             return array
         } else if (fromObject is Dictionary<String, NSObject>) {
             let obj = NSObject.objectForType(type)
+            
+            if obj is NSDictionary {
+                return fromObject
+            }
+            
             fillObject(obj, data: fromObject as! Dictionary<String, NSObject>)
 
             return obj


### PR DESCRIPTION
…sked to deserialize an NSDictionary

The old serializer could serialize an NSDictionary -- I'm not sure if you want to stick this fix somewhere else in the code, but it was the simplest fix.