### PR TITLE
Override Serializer Key Fix

### DIFF
--- a/Cereal/Serialization/CerealizerBase.swift
+++ b/Cereal/Serialization/CerealizerBase.swift
@@ -46,6 +46,8 @@ public class CerealizerBase: NSObject, Cerealizer {
 
         let properties = CMTypeIntrospector(t: obj.dynamicType).properties()
         for property in properties {
+            let key = self.serializeKeyTransform == nil ? property.name : self.serializeKeyTransform!.transformKey(property.name)
+            
             if (obj is Cerealizable) {
                 let cerealizable = obj as! Cerealizable
                 if (!cerealizable.shouldSerializeProperty(property.name)) {
@@ -53,7 +55,7 @@ public class CerealizerBase: NSObject, Cerealizer {
                 }
 
                 if (cerealizable.overrideSerializeProperty(property.name)) {
-                    bag[property.name] = cerealizable.serializeProperty(property.name)
+                    bag[key] = cerealizable.serializeProperty(property.name)
                     continue
                 }
             }
@@ -63,7 +65,6 @@ public class CerealizerBase: NSObject, Cerealizer {
                 continue
             }
 
-            let key = self.serializeKeyTransform == nil ? property.name : self.serializeKeyTransform!.transformKey(property.name)
             bag[key] = serializeValue(value!)
         }
 

--- a/Cereal/Serialization/CerealizerBase.swift
+++ b/Cereal/Serialization/CerealizerBase.swift
@@ -46,7 +46,7 @@ public class CerealizerBase: NSObject, Cerealizer {
 
         let properties = CMTypeIntrospector(t: obj.dynamicType).properties()
         for property in properties {
-            let key = self.serializeKeyTransform == nil ? property.name : self.serializeKeyTransform!.transformKey(property.name)
+            let key = self.serializeKeyTransform?.transformKey(property.name) ?? property.name
             
             if (obj is Cerealizable) {
                 let cerealizable = obj as! Cerealizable


### PR DESCRIPTION
Fixed an issue where if you overrode the serializeProperty delegate method, it would use the property.name as the key instead of the transformed key like it does farther down the control flow
